### PR TITLE
Remove debug logging for dirty body damage capability

### DIFF
--- a/src/main/java/sfiomn/legendarysurvivaloverhaul/common/capabilities/bodydamage/BodyDamageCapability.java
+++ b/src/main/java/sfiomn/legendarysurvivaloverhaul/common/capabilities/bodydamage/BodyDamageCapability.java
@@ -78,8 +78,6 @@ public class BodyDamageCapability implements IBodyDamageCapability
 
 	@Override
 	public boolean isDirty() {
-		LegendarySurvivalOverhaul.LOGGER.debug("body damage is dirty ?");
-		LegendarySurvivalOverhaul.LOGGER.debug(this.expectedBrokenHearts + " =? " + this.oldExpectedBrokenHearts);
 		for (BodyPart bodyPart: this.bodyParts.values()) {
 			if (bodyPart.isDirty())
 				return true;


### PR DESCRIPTION
As far as I'm aware, this should've been debugged personally with breakpoints instead of logging directly to the console.

This logging creates spam on the debug.log every time the capability is checked for dirtiness (basically every tick).

This pull request removes the problematic code and shouldn't affect mod functionality.