### PR TITLE
Update Origins compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,10 @@ repositories {
         name = "CurseForge"
         url = "https://minecraft.curseforge.com/api/maven/"
     }
+
+    // Flat dir for local jars
+    // Required to use Connector-transformed Origins within the project with remapped vanilla references
+    flatDir { dir "${rootProject.rootDir}/libs/" }
 }
 
 dependencies {
@@ -171,7 +175,6 @@ dependencies {
     compileOnly(fg.deobf("curse.maven:serene-seasons-291874:5790653"))
     compileOnly(fg.deobf("curse.maven:glitchcore-955399:5787839"))
     compileOnly(fg.deobf("curse.maven:terrafirmacraft-302973:6187491"))
-    compileOnly(fg.deobf("curse.maven:origins-474438:5314209"))
     compileOnly(fg.deobf("curse.maven:mutantmonsters-852665:5107399"))
     compileOnly(fg.deobf("curse.maven:vampirism-233029:5990073"))
     compileOnly(fg.deobf("curse.maven:supplementaries-412082:6463022"))
@@ -181,6 +184,16 @@ dependencies {
     compileOnly(fg.deobf("curse.maven:artifacts-312353:6399828"))
     compileOnly(fg.deobf("curse.maven:overflowingbars-852662:5763974"))
     compileOnly(fg.deobf("curse.maven:puzzlelib-495476:6387081"))
+
+
+    // Origins Fabric connector-transformed jars, in root project dir `/libs/`
+    // The Origins jar is modified to have Reach Entity Attributes removed -
+    // You could also exclude reach entity attributes here using gradle
+    compileOnly ("io.github:Origins-1.10.2+mc.1.20.x_mapped_srg_1.20.1")
+    compileOnly ("io.github:Origins-1.10.2+mc.1.20.x\$apoli-2.9.2+mc.1.20.x_mapped_srg_1.20.1")
+    compileOnly ("io.github:Origins-1.10.2+mc.1.20.x\$apoli-2.9.2+mc.1.20.x\$calio-1.11.2+mc.1.20.x_mapped_srg_1.20.1")
+    compileOnly ("io.github:Origins-1.10.2+mc.1.20.x\$apoli-2.9.2+mc.1.20.x\$cardinal-components-base-5.2.1_mapped_srg_1.20.1")
+    compileOnly ("io.github:Origins-1.10.2+mc.1.20.x\$apoli-2.9.2+mc.1.20.x\$cardinal-components-entity-5.2.1_mapped_srg_1.20.1")
 
     //implementation(fg.deobf("curse.maven:weather2-237746:5244118"))
     //implementation(fg.deobf("curse.maven:coroutil-237749:5096038"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mod_name=Legendary Survival Overhaul
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU General Public License v3.1
 # The mod version. See https://semver.org/
-mod_version=2.3.23.1
+mod_version=2.3.23.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/sfiomn/legendarysurvivaloverhaul/common/integration/origins/OriginsDynamicModifier.java
+++ b/src/main/java/sfiomn/legendarysurvivaloverhaul/common/integration/origins/OriginsDynamicModifier.java
@@ -1,12 +1,10 @@
 package sfiomn.legendarysurvivaloverhaul.common.integration.origins;
 
-import io.github.edwinmindcraft.origins.api.OriginsAPI;
-import io.github.edwinmindcraft.origins.api.capabilities.IOriginContainer;
-import io.github.edwinmindcraft.origins.api.origin.Origin;
-import net.minecraft.resources.ResourceKey;
+import io.github.apace100.origins.component.OriginComponent;
+import io.github.apace100.origins.origin.Origin;
+import io.github.apace100.origins.registry.ModComponents;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
-import net.minecraftforge.common.util.LazyOptional;
 import sfiomn.legendarysurvivaloverhaul.LegendarySurvivalOverhaul;
 import sfiomn.legendarysurvivaloverhaul.api.data.json.JsonTemperatureResistance;
 import sfiomn.legendarysurvivaloverhaul.api.data.manager.TemperatureDataManager;
@@ -14,7 +12,8 @@ import sfiomn.legendarysurvivaloverhaul.api.temperature.DynamicModifierBase;
 import sfiomn.legendarysurvivaloverhaul.api.temperature.TemperatureEnum;
 
 public class OriginsDynamicModifier extends DynamicModifierBase {
-    public OriginsDynamicModifier() {}
+    public OriginsDynamicModifier() {
+    }
 
     @Override
     public float applyDynamicPlayerInfluence(Player player, float currentTemperature, float currentResistance) {
@@ -25,29 +24,24 @@ public class OriginsDynamicModifier extends DynamicModifierBase {
         float effectiveResistance = 0.0f;
         float diffToAverage = currentTemperature - TemperatureEnum.NORMAL.getMiddle();
 
-        LazyOptional<IOriginContainer> optionalOrigin = player.getCapability(OriginsAPI.ORIGIN_CONTAINER);
-        if (optionalOrigin.isPresent() && optionalOrigin.resolve().isPresent()) {
-            IOriginContainer origins = optionalOrigin.resolve().get();
-            for (ResourceKey<Origin> origin : origins.getOrigins().values()) {
-                JsonTemperatureResistance config = TemperatureDataManager.getOrigin(origin.location());
-                if (config != null) {
-
-                    double maxResistance = config.thermalResistance;
-
-                    if (diffToAverage > 0) {
-                        maxResistance += config.heatResistance;
-                        effectiveResistance = (float) Mth.clamp(maxResistance, currentResistance, diffToAverage + currentResistance);
-                        effectiveResistance = -effectiveResistance;
-                    } else if (diffToAverage < 0) {
-                        maxResistance += config.coldResistance;
-                        diffToAverage = -diffToAverage;
-                        currentResistance = -currentResistance;
-                        effectiveResistance = (float) Mth.clamp(maxResistance, currentResistance, diffToAverage + currentResistance);
-                    }
-
+        OriginComponent component = ModComponents.ORIGIN.get(player);
+        for (Origin origin : component.getOrigins().values()) {
+            JsonTemperatureResistance config = TemperatureDataManager.getOrigin(origin.getIdentifier());
+            if (config != null) {
+                double maxResistance = config.thermalResistance;
+                if (diffToAverage > 0) {
+                    maxResistance += config.heatResistance;
+                    effectiveResistance = (float) Mth.clamp(maxResistance, currentResistance, diffToAverage + currentResistance);
+                    effectiveResistance = -effectiveResistance;
+                } else if (diffToAverage < 0) {
+                    maxResistance += config.coldResistance;
+                    diffToAverage = -diffToAverage;
+                    currentResistance = -currentResistance;
+                    effectiveResistance = (float) Mth.clamp(maxResistance, currentResistance, diffToAverage + currentResistance);
                 }
             }
         }
+
 
         return effectiveResistance;
     }

--- a/src/main/java/sfiomn/legendarysurvivaloverhaul/common/integration/origins/OriginsModifier.java
+++ b/src/main/java/sfiomn/legendarysurvivaloverhaul/common/integration/origins/OriginsModifier.java
@@ -1,11 +1,9 @@
 package sfiomn.legendarysurvivaloverhaul.common.integration.origins;
 
-import io.github.edwinmindcraft.origins.api.OriginsAPI;
-import io.github.edwinmindcraft.origins.api.capabilities.IOriginContainer;
-import io.github.edwinmindcraft.origins.api.origin.Origin;
-import net.minecraft.resources.ResourceKey;
+import io.github.apace100.origins.component.OriginComponent;
+import io.github.apace100.origins.origin.Origin;
+import io.github.apace100.origins.registry.ModComponents;
 import net.minecraft.world.entity.player.Player;
-import net.minecraftforge.common.util.LazyOptional;
 import sfiomn.legendarysurvivaloverhaul.LegendarySurvivalOverhaul;
 import sfiomn.legendarysurvivaloverhaul.api.data.json.JsonTemperatureResistance;
 import sfiomn.legendarysurvivaloverhaul.api.data.manager.TemperatureDataManager;
@@ -21,16 +19,13 @@ public class OriginsModifier extends ModifierBase {
         if (!LegendarySurvivalOverhaul.originsLoaded)
             return 0.0f;
 
-        LazyOptional<IOriginContainer> optionalOrigin = player.getCapability(OriginsAPI.ORIGIN_CONTAINER);
+        OriginComponent component = ModComponents.ORIGIN.get(player);
 
         float temp = 0.0f;
 
-        if (optionalOrigin.isPresent() && optionalOrigin.resolve().isPresent()) {
-            IOriginContainer origins = optionalOrigin.resolve().get();
-            for (ResourceKey<Origin> origin : origins.getOrigins().values()) {
-                JsonTemperatureResistance config = TemperatureDataManager.getOrigin(origin.location());
-                temp += config != null ? config.temperature : 0;
-            }
+        for (Origin origin : component.getOrigins().values()) {
+            JsonTemperatureResistance config = TemperatureDataManager.getOrigin(origin.getIdentifier());
+            temp += config != null ? config.temperature : 0;
         }
 
         return temp;

--- a/src/main/java/sfiomn/legendarysurvivaloverhaul/common/integration/origins/OriginsUtil.java
+++ b/src/main/java/sfiomn/legendarysurvivaloverhaul/common/integration/origins/OriginsUtil.java
@@ -1,8 +1,10 @@
 package sfiomn.legendarysurvivaloverhaul.common.integration.origins;
 
-import io.github.edwinmindcraft.origins.api.OriginsAPI;
-import io.github.edwinmindcraft.origins.api.origin.Origin;
-import net.minecraft.resources.ResourceKey;
+import io.github.apace100.origins.Origins;
+import io.github.apace100.origins.component.OriginComponent;
+import io.github.apace100.origins.origin.Origin;
+import io.github.apace100.origins.origin.OriginRegistry;
+import io.github.apace100.origins.registry.ModComponents;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import sfiomn.legendarysurvivaloverhaul.LegendarySurvivalOverhaul;
@@ -14,42 +16,38 @@ import sfiomn.legendarysurvivaloverhaul.config.Config;
 import sfiomn.legendarysurvivaloverhaul.registry.MobEffectRegistry;
 
 public class OriginsUtil {
-    public static ResourceKey<Origin> BLAZEBORN = ResourceKey.create(OriginsAPI.getOriginsRegistry().key(), new ResourceLocation(OriginsAPI.MODID, "blazeborn"));
-    public static ResourceKey<Origin> MERLING = ResourceKey.create(OriginsAPI.getOriginsRegistry().key(), new ResourceLocation(OriginsAPI.MODID, "merling"));
-    public static ResourceKey<Origin> PHANTOM = ResourceKey.create(OriginsAPI.getOriginsRegistry().key(), new ResourceLocation(OriginsAPI.MODID, "phantom"));
-    public static ResourceKey<Origin> AVIAN = ResourceKey.create(OriginsAPI.getOriginsRegistry().key(), new ResourceLocation(OriginsAPI.MODID, "avian"));
-    public static ResourceKey<Origin> ELYTRIAN = ResourceKey.create(OriginsAPI.getOriginsRegistry().key(), new ResourceLocation(OriginsAPI.MODID, "elytrian"));
-    public static ResourceKey<Origin> SHULK = ResourceKey.create(OriginsAPI.getOriginsRegistry().key(), new ResourceLocation(OriginsAPI.MODID, "shulk"));
+    public static Origin BLAZEBORN = OriginRegistry.get(new ResourceLocation(Origins.MODID, "blazeborn"));
+    public static Origin MERLING = OriginRegistry.get(new ResourceLocation(Origins.MODID, "merling"));
+    public static Origin PHANTOM = OriginRegistry.get(new ResourceLocation(Origins.MODID, "phantom"));
+    public static Origin AVIAN = OriginRegistry.get(new ResourceLocation(Origins.MODID, "avian"));
+    public static Origin ELYTRIAN = OriginRegistry.get(new ResourceLocation(Origins.MODID, "elytrian"));
+    public static Origin SHULK = OriginRegistry.get(new ResourceLocation(Origins.MODID, "shulk"));
 
-    public static boolean isOrigin(Player player, ResourceKey<Origin> origin) {
+    public static boolean isOrigin(Player player, Origin origin) {
         return LegendarySurvivalOverhaul.originsLoaded &&
-                player.getCapability(OriginsAPI.ORIGIN_CONTAINER).isPresent() &&
-                player.getCapability(OriginsAPI.ORIGIN_CONTAINER).resolve().isPresent() &&
-                player.getCapability(OriginsAPI.ORIGIN_CONTAINER).resolve().get().getOrigins().containsValue(origin);
+                ModComponents.ORIGIN.get(player).getOrigins().containsValue(origin);
     }
 
     public static void assignOriginsFeatures(Player player) {
-        player.getCapability(OriginsAPI.ORIGIN_CONTAINER).ifPresent(
-                origins -> {
-                    if (origins.getOrigins().containsValue(MERLING)) {
-                        removeThirstEffect(player);
-                    } else if (origins.getOrigins().containsValue(SHULK)) {
-                        addExtraThirstExhaustion(player, Config.Baked.extraThirstExhaustionShulk);
-                    } else if (origins.getOrigins().containsValue(PHANTOM)) {
-                        addExtraThirstExhaustion(player, Config.Baked.extraThirstExhaustionPhantom);
-                    }
+        OriginComponent component = ModComponents.ORIGIN.get(player);
+        
+        if (component.getOrigins().containsValue(MERLING)) {
+            removeThirstEffect(player);
+        } else if (component.getOrigins().containsValue(SHULK)) {
+            addExtraThirstExhaustion(player, Config.Baked.extraThirstExhaustionShulk);
+        } else if (component.getOrigins().containsValue(PHANTOM)) {
+            addExtraThirstExhaustion(player, Config.Baked.extraThirstExhaustionPhantom);
+        }
 
-                    adaptWetnessDeactivation(player,
-                            origins.getOrigins().containsValue(MERLING) ||
-                                    origins.getOrigins().containsValue(BLAZEBORN));
+        adaptWetnessDeactivation(player,
+                component.getOrigins().containsValue(MERLING) ||
+                        component.getOrigins().containsValue(BLAZEBORN));
 
-                    adaptHighAltitudeImmunity(player,
-                            origins.getOrigins().containsValue(AVIAN) ||
-                                    origins.getOrigins().containsValue(ELYTRIAN));
+        adaptHighAltitudeImmunity(player,
+                component.getOrigins().containsValue(AVIAN) ||
+                        component.getOrigins().containsValue(ELYTRIAN));
 
-                    adaptOnFireImmunity(player, origins.getOrigins().containsValue(BLAZEBORN));
-                }
-        );
+        adaptOnFireImmunity(player, component.getOrigins().containsValue(BLAZEBORN));
     }
 
     private static void adaptWetnessDeactivation(Player player, boolean shouldDeactivate) {

--- a/src/main/java/sfiomn/legendarysurvivaloverhaul/common/integration/origins/OriginsUtil.java
+++ b/src/main/java/sfiomn/legendarysurvivaloverhaul/common/integration/origins/OriginsUtil.java
@@ -1,9 +1,7 @@
 package sfiomn.legendarysurvivaloverhaul.common.integration.origins;
 
-import io.github.apace100.origins.Origins;
 import io.github.apace100.origins.component.OriginComponent;
 import io.github.apace100.origins.origin.Origin;
-import io.github.apace100.origins.origin.OriginRegistry;
 import io.github.apace100.origins.registry.ModComponents;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
@@ -16,38 +14,42 @@ import sfiomn.legendarysurvivaloverhaul.config.Config;
 import sfiomn.legendarysurvivaloverhaul.registry.MobEffectRegistry;
 
 public class OriginsUtil {
-    public static Origin BLAZEBORN = OriginRegistry.get(new ResourceLocation(Origins.MODID, "blazeborn"));
-    public static Origin MERLING = OriginRegistry.get(new ResourceLocation(Origins.MODID, "merling"));
-    public static Origin PHANTOM = OriginRegistry.get(new ResourceLocation(Origins.MODID, "phantom"));
-    public static Origin AVIAN = OriginRegistry.get(new ResourceLocation(Origins.MODID, "avian"));
-    public static Origin ELYTRIAN = OriginRegistry.get(new ResourceLocation(Origins.MODID, "elytrian"));
-    public static Origin SHULK = OriginRegistry.get(new ResourceLocation(Origins.MODID, "shulk"));
 
-    public static boolean isOrigin(Player player, Origin origin) {
-        return LegendarySurvivalOverhaul.originsLoaded &&
-                ModComponents.ORIGIN.get(player).getOrigins().containsValue(origin);
+    private static boolean hasOriginFromList(Player player, java.util.List<? extends String> originIds) {
+        if (!LegendarySurvivalOverhaul.originsLoaded || originIds == null || originIds.isEmpty()) {
+            return false;
+        }
+        
+        OriginComponent component = ModComponents.ORIGIN.get(player);
+        for (Origin origin : component.getOrigins().values()) {
+            ResourceLocation originId = origin.getIdentifier();
+            String originIdString = originId.toString();
+            if (originIds.contains(originIdString)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean canDrinkLava(Player player) {
+        return hasOriginFromList(player, Config.Baked.originsWithLavaDrinking);
     }
 
     public static void assignOriginsFeatures(Player player) {
-        OriginComponent component = ModComponents.ORIGIN.get(player);
-        
-        if (component.getOrigins().containsValue(MERLING)) {
-            removeThirstEffect(player);
-        } else if (component.getOrigins().containsValue(SHULK)) {
-            addExtraThirstExhaustion(player, Config.Baked.extraThirstExhaustionShulk);
-        } else if (component.getOrigins().containsValue(PHANTOM)) {
-            addExtraThirstExhaustion(player, Config.Baked.extraThirstExhaustionPhantom);
+        if (!LegendarySurvivalOverhaul.originsLoaded) {
+            return;
         }
+        
 
-        adaptWetnessDeactivation(player,
-                component.getOrigins().containsValue(MERLING) ||
-                        component.getOrigins().containsValue(BLAZEBORN));
-
-        adaptHighAltitudeImmunity(player,
-                component.getOrigins().containsValue(AVIAN) ||
-                        component.getOrigins().containsValue(ELYTRIAN));
-
-        adaptOnFireImmunity(player, component.getOrigins().containsValue(BLAZEBORN));
+        if (hasOriginFromList(player, Config.Baked.originsWithThirstEffectImmunity)) {
+            removeThirstEffect(player);
+        }
+        if (hasOriginFromList(player, Config.Baked.originsWithExtraThirstExhaustion)) {
+            addExtraThirstExhaustion(player, Config.Baked.originsExtraThirstExhaustionValue);
+        }
+        adaptWetnessDeactivation(player, hasOriginFromList(player, Config.Baked.originsWithWetnessImmunity));
+        adaptHighAltitudeImmunity(player, hasOriginFromList(player, Config.Baked.originsWithHighAltitudeImmunity));
+        adaptOnFireImmunity(player, hasOriginFromList(player, Config.Baked.originsWithOnFireImmunity));
     }
 
     private static void adaptWetnessDeactivation(Player player, boolean shouldDeactivate) {

--- a/src/main/java/sfiomn/legendarysurvivaloverhaul/config/Config.java
+++ b/src/main/java/sfiomn/legendarysurvivaloverhaul/config/Config.java
@@ -142,6 +142,11 @@ public class Config
 
 		public final ForgeConfigSpec.DoubleValue tfcItemHeatMultiplier;
 		public final ForgeConfigSpec.DoubleValue tfcTemperatureMultiplier;
+		
+		// > Temperature Origins Integration
+		public final ForgeConfigSpec.ConfigValue<List<? extends String>> originsWithWetnessImmunity;
+		public final ForgeConfigSpec.ConfigValue<List<? extends String>> originsWithHighAltitudeImmunity;
+		public final ForgeConfigSpec.ConfigValue<List<? extends String>> originsWithOnFireImmunity;
 
 		public final ForgeConfigSpec.BooleanValue sereneSeasonsEnabled;
 		public final ForgeConfigSpec.BooleanValue ssTropicalSeasonsEnabled;
@@ -198,11 +203,13 @@ public class Config
 		public final ForgeConfigSpec.DoubleValue saturationLava;
 		public final ForgeConfigSpec.BooleanValue glassBottleLootAfterDrink;
 
-		// > Integration
+		// > Thirst Integration
+		public final ForgeConfigSpec.ConfigValue<List<? extends String>> originsWithThirstEffectImmunity;
+		public final ForgeConfigSpec.ConfigValue<List<? extends String>> originsWithExtraThirstExhaustion;
+		public final ForgeConfigSpec.ConfigValue<List<? extends String>> originsWithLavaDrinking;
 		public final ForgeConfigSpec.IntValue hydrationLavaBlazeborn;
 		public final ForgeConfigSpec.DoubleValue saturationLavaBlazeborn;
-		public final ForgeConfigSpec.DoubleValue extraThirstExhaustionShulk;
-		public final ForgeConfigSpec.DoubleValue extraThirstExhaustionPhantom;
+		public final ForgeConfigSpec.DoubleValue originsExtraThirstExhaustionValue;
 		public final ForgeConfigSpec.BooleanValue thirstEnabledIfVampire;
 
 		// Health Overhaul
@@ -670,6 +677,28 @@ public class Config
 			builder.pop();
 			builder.pop();
 
+			builder.comment(" Origins mod integration for temperature system.")
+					.push("origins");
+			originsWithWetnessImmunity = builder
+					.comment(" Origins that are immune to wetness effects.",
+							" Format: 'modid:origin_name' (e.g., 'origins:merling')")
+					.defineListAllowEmpty("Origins With Wetness Immunity",
+							List.of("origins:merling", "origins:blazeborn"),
+							Config::validateResourceLocationString);
+			originsWithHighAltitudeImmunity = builder
+					.comment(" Origins that are immune to high altitude coldness.",
+							" Format: 'modid:origin_name' (e.g., 'origins:avian')")
+					.defineListAllowEmpty("Origins With High Altitude Immunity",
+							List.of("origins:avian", "origins:elytrian"),
+							Config::validateResourceLocationString);
+			originsWithOnFireImmunity = builder
+					.comment(" Origins that are immune to on fire temperature effects.",
+							" Format: 'modid:origin_name' (e.g., 'origins:blazeborn')")
+					.defineListAllowEmpty("Origins With On Fire Immunity",
+							List.of("origins:blazeborn"),
+							Config::validateResourceLocationString);
+			builder.pop();
+
 			builder.pop();
 			builder.pop();
 
@@ -738,42 +767,42 @@ public class Config
 			builder.pop();
 
 			builder.push("integration");
-			builder.push("origins");
-
-			builder.comment(" Temperature won't increase while on fire",
-					" Immune to wetness",
-					" Can drink lava")
-					.push("blazeborn");
+			builder.comment(" Origins mod integration for thirst system.")
+					.push("origins");
+			originsWithThirstEffectImmunity = builder
+					.comment(" Origins that are immune to thirst effects (e.g., from dirty water).",
+							" Format: 'modid:origin_name' (e.g., 'origins:merling')")
+					.defineListAllowEmpty("Origins With Thirst Effect Immunity",
+							List.of("origins:merling"),
+							Config::validateResourceLocationString);
+			
+			originsWithExtraThirstExhaustion = builder
+					.comment(" Origins that have extra thirst exhaustion added every 20 ticks.",
+							" The exhaustion amount is defined in 'Extra Thirst Exhaustion' config below.",
+							" Format: 'modid:origin_name' (e.g., 'origins:shulk')")
+					.defineListAllowEmpty("Origins With Extra Thirst Exhaustion",
+							List.of("origins:shulk", "origins:phantom"),
+							Config::validateResourceLocationString);
+			
+			originsWithLavaDrinking = builder
+					.comment(" Origins that can drink lava for hydration.",
+							" The hydration and saturation amounts are defined in 'Lava Hydration' and 'Lava Saturation' configs below.",
+							" Format: 'modid:origin_name' (e.g., 'origins:blazeborn')")
+					.defineListAllowEmpty("Origins With Lava Drinking",
+							List.of("origins:blazeborn"),
+							Config::validateResourceLocationString);
+			
 			hydrationLavaBlazeborn = builder
-					.comment(" Amount of hydration recovered when drinking from lava.")
-					.defineInRange("Lava Hydration For Blazeborn", 3, 0, 20);
+					.comment(" Amount of hydration recovered when origins in 'Origins With Lava Drinking' drink from lava.")
+					.defineInRange("Lava Hydration", 3, 0, 20);
 			saturationLavaBlazeborn = builder
-					.comment(" Amount of saturation recovered when drinking from lava.")
-					.defineInRange("Lava Saturation For Blazeborn", 1.0, 0, 20);
-			builder.pop();
-
-			builder.comment(" Immune to wetness",
-					"Immune to Thirst Effect").push("merling");
-			builder.pop();
-
-			builder.comment(" Immune to high altitude coldness").push("elytrian");
-			builder.pop();
-
-			builder.comment(" Immune to high altitude coldness").push("avian");
-			builder.pop();
-
-			builder.comment(" Thirst depletes slightly faster").push("shulk");
-			extraThirstExhaustionShulk = builder
-					.comment(" Amount of thirst exhaustion added every 20 ticks.")
-					.defineInRange("Extra Thirst Exhaustion For Shulk", 0.1, 0, 1000);
-			builder.pop();
-
-			builder.comment(" Thirst depletes slightly faster").push("phantom");
-			extraThirstExhaustionPhantom = builder
-					.comment(" Amount of thirst exhaustion added every 20 ticks.")
-					.defineInRange("Extra Thirst Exhaustion For Phantom", 0.1, 0, 1000);
-			builder.pop();
-
+					.comment(" Amount of saturation recovered when origins in 'Origins With Lava Drinking' drink from lava.")
+					.defineInRange("Lava Saturation", 1.0, 0, 20);
+			
+			originsExtraThirstExhaustionValue = builder
+					.comment(" Amount of thirst exhaustion added every 20 ticks for origins in 'Origins With Extra Thirst Exhaustion'.")
+					.defineInRange("Extra Thirst Exhaustion", 0.1, 0, 1000);
+			
 			builder.pop();
 
 			builder.push("vampirism");
@@ -1059,6 +1088,14 @@ public class Config
 		return obj instanceof final String entityName && ForgeRegistries.ENTITY_TYPES.containsKey(new ResourceLocation(entityName));
 	}
 
+	private static boolean validateResourceLocationString(final Object obj)
+	{
+		if (!(obj instanceof String str)) {
+			return false;
+		}
+		return ResourceLocation.tryParse(str) != null;
+	}
+
 	public static class Client
 	{
 		public final ForgeConfigSpec.BooleanValue foodSaturationDisplayed;
@@ -1335,6 +1372,10 @@ public class Config
 
 		public static double tfcItemHeatMultiplier;
 		public static double tfcTemperatureMultiplier;
+		
+		public static List<? extends String> originsWithWetnessImmunity;
+		public static List<? extends String> originsWithHighAltitudeImmunity;
+		public static List<? extends String> originsWithOnFireImmunity;
 
 		public static boolean sereneSeasonsEnabled;
 		public static boolean ssTropicalSeasonsEnabled;
@@ -1390,10 +1431,14 @@ public class Config
 		public static int hydrationLava;
 		public static double saturationLava;
 		public static boolean glassBottleLootAfterDrink;
+		
+		public static List<? extends String> originsWithThirstEffectImmunity;
+		public static List<? extends String> originsWithExtraThirstExhaustion;
+		public static List<? extends String> originsWithLavaDrinking;
 		public static int hydrationLavaBlazeborn;
 		public static double saturationLavaBlazeborn;
-		public static double extraThirstExhaustionShulk;
-		public static double extraThirstExhaustionPhantom;
+		public static double originsExtraThirstExhaustionValue;
+		
 		public static boolean thirstEnabledIfVampire;
 
 		// Health Overhaul
@@ -1608,6 +1653,10 @@ public class Config
 
 				tfcItemHeatMultiplier = COMMON.tfcItemHeatMultiplier.get();
 				tfcTemperatureMultiplier = COMMON.tfcTemperatureMultiplier.get();
+				
+				originsWithWetnessImmunity = COMMON.originsWithWetnessImmunity.get();
+				originsWithHighAltitudeImmunity = COMMON.originsWithHighAltitudeImmunity.get();
+				originsWithOnFireImmunity = COMMON.originsWithOnFireImmunity.get();
 
 				sereneSeasonsEnabled = COMMON.sereneSeasonsEnabled.get();
 				ssTropicalSeasonsEnabled = COMMON.ssTropicalSeasonsEnabled.get();
@@ -1667,10 +1716,13 @@ public class Config
 
 				glassBottleLootAfterDrink = COMMON.glassBottleLootAfterDrink.get();
 
+				originsWithThirstEffectImmunity = COMMON.originsWithThirstEffectImmunity.get();
+				originsWithExtraThirstExhaustion = COMMON.originsWithExtraThirstExhaustion.get();
+				originsWithLavaDrinking = COMMON.originsWithLavaDrinking.get();
 				hydrationLavaBlazeborn = COMMON.hydrationLavaBlazeborn.get();
 				saturationLavaBlazeborn = COMMON.saturationLavaBlazeborn.get();
-				extraThirstExhaustionShulk = COMMON.extraThirstExhaustionShulk.get();
-				extraThirstExhaustionPhantom = COMMON.extraThirstExhaustionPhantom.get();
+				originsExtraThirstExhaustionValue = COMMON.originsExtraThirstExhaustionValue.get();
+				
 				thirstEnabledIfVampire = COMMON.thirstEnabledIfVampire.get();
 
 				healthOverhaulEnabled = COMMON.healthOverhaulEnabled.get();

--- a/src/main/java/sfiomn/legendarysurvivaloverhaul/util/internal/ThirstUtilInternal.java
+++ b/src/main/java/sfiomn/legendarysurvivaloverhaul/util/internal/ThirstUtilInternal.java
@@ -213,7 +213,7 @@ public class ThirstUtilInternal implements IThirstUtil {
                 }
 
                 if (LegendarySurvivalOverhaul.originsLoaded) {
-                    if (OriginsUtil.isOrigin(player, OriginsUtil.BLAZEBORN) &&
+                    if (OriginsUtil.canDrinkLava(player) &&
                             (fluidState.is(Fluids.FLOWING_LAVA) || fluidState.is(Fluids.LAVA)))
                         return new JsonThirstBlock(Config.Baked.hydrationLavaBlazeborn, (float) Config.Baked.saturationLavaBlazeborn, new ArrayList<>(), new HashMap<>());
                 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -106,3 +106,11 @@ Making survival harder. Highly configurable so you can play the way you want.
     versionRange="[0.11.2.1.1,)"
     ordering="BEFORE"
     side="BOTH"
+
+
+[[dependencies.${mod_id}]]
+    modId="origins"
+    mandatory=false
+    versionRange="[1.10.2,)"
+    ordering="BEFORE"
+    side="BOTH"


### PR DESCRIPTION
Updates integration with Origins: 
- Update to and require newer than 1.10.2 if present (new mod page - see https://www.curseforge.com/minecraft/mc-mods/origins/files/7149659) 
- All previously hardcoded Origins compats (lava drinking, temperature immunities, etc.) have also been changed into a configurable list, so that modpack makers can easily add and remove Origins to these integrations. 

See also: https://github.com/apace100/origins-fabric/issues/853